### PR TITLE
Limit number of variables for CAMS backfill

### DIFF
--- a/nwp/jobs.py
+++ b/nwp/jobs.py
@@ -1,4 +1,3 @@
-import datetime
 import datetime as dt
 import json
 from collections.abc import Callable
@@ -87,7 +86,7 @@ for r in ["00", "06", "12", "18"]:
 
 @dagster.daily_partitioned_config(start_date=dt.datetime(2015, 1, 1))
 def CAMSDailyPartitionConfig(start: dt.datetime, _end: dt.datetime) -> dict[str, Any]:
-    if start < datetime.datetime.utcnow() - datetime.timedelta(days=30):
+    if start < dt.datetime.utcnow() - dt.timedelta(days=30):
         # Only use subset for tape-based backfill
         single_level_variables = ['total_absorption_aerosol_optical_depth_400nm', 'total_absorption_aerosol_optical_depth_440nm',
     'total_absorption_aerosol_optical_depth_469nm', 'total_absorption_aerosol_optical_depth_500nm', 'total_absorption_aerosol_optical_depth_532nm',

--- a/nwp/jobs.py
+++ b/nwp/jobs.py
@@ -1,3 +1,4 @@
+import datetime
 import datetime as dt
 import json
 from collections.abc import Callable
@@ -86,10 +87,23 @@ for r in ["00", "06", "12", "18"]:
 
 @dagster.daily_partitioned_config(start_date=dt.datetime(2015, 1, 1))
 def CAMSDailyPartitionConfig(start: dt.datetime, _end: dt.datetime) -> dict[str, Any]:
-    config = CAMSConfig(
-        date=start.strftime("%Y-%m-%d"),
-        raw_dir="/mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/NWP/CAMS/raw",
-    )
+    if start < datetime.datetime.utcnow() - datetime.timedelta(days=30):
+        # Only use subset for tape-based backfill
+        single_level_variables = ['total_absorption_aerosol_optical_depth_400nm', 'total_absorption_aerosol_optical_depth_440nm',
+    'total_absorption_aerosol_optical_depth_469nm', 'total_absorption_aerosol_optical_depth_500nm', 'total_absorption_aerosol_optical_depth_532nm',
+    'total_absorption_aerosol_optical_depth_550nm', 'total_absorption_aerosol_optical_depth_645nm', 'total_absorption_aerosol_optical_depth_670nm',]
+        multi_level_variables = ['aerosol_extinction_coefficient_532nm',]
+        config = CAMSConfig(
+            date=start.strftime("%Y-%m-%d"),
+            raw_dir="/mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/NWP/CAMS/raw",
+            single_variables=single_level_variables,
+            multi_variables=multi_level_variables,
+        )
+    else:
+        config = CAMSConfig(
+            date=start.strftime("%Y-%m-%d"),
+            raw_dir="/mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/NWP/CAMS/raw",
+        )
     return {"ops": {"fetch_cams_forecast_for_day": {"config": json.loads(config.json())}}}
 
 


### PR DESCRIPTION
# Pull Request

## Description

Limits number of backfill variables for CAMS global forecast for runs more than 30 days old, as that is when tape backups happen.

Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
