### PR TITLE
Add schedules to run scan jobs on a daily cadence

### DIFF
--- a/local_archives/__init__.py
+++ b/local_archives/__init__.py
@@ -28,8 +28,13 @@ all_jobs: list[dg.JobDefinition] = [
     *nwp.all_jobs,
 ]
 
+all_schedules: list[dg.ScheduleDefinition] = [
+    *nwp.all_schedules,
+]
+
 defs = dg.Definitions(
     assets=all_assets,
     resources=resources_by_env[os.getenv("ENVIRONMENT", "local")],
     jobs=all_jobs,
+    schedules=all_schedules,
 )

--- a/local_archives/nwp/__init__.py
+++ b/local_archives/nwp/__init__.py
@@ -14,3 +14,47 @@ all_jobs: list[dg.JobDefinition] = [
     jobs.scan_nwp_raw_archive,
     jobs.scan_nwp_zarr_archive,
 ]
+
+@dg.schedule(
+    job=jobs.scan_nwp_raw_archive,
+    cron_schedule="0 3 * * *",
+    default_status=dg.DefaultScheduleStatus.RUNNING,
+)
+def scan_nwp_raw_archives_schedule(context: dg.ScheduleEvaluationContext) -> dg.RunRequest:
+    """Scan the raw archives.
+
+    Yields a RunRequest for the scan_nwp_raw_archive job for each raw archive.
+    """
+    raw_assets: list[dg.AssetsDefinition] = [
+        a for a in all_assets if "raw_archive" in a.key.path
+    ]
+    for a in raw_assets:
+        yield dg.RunRequest(
+            run_key=f"scan_nwp_{a.key.path[1]}_{a.key.path[2]}_{a.key.path[3]}",
+            run_config=jobs.gen_run_config(a.key)
+        )
+
+@dg.schedule(
+    job=jobs.scan_nwp_zarr_archive,
+    cron_schedule="15 3 * * *",
+    default_status=dg.DefaultScheduleStatus.RUNNING,
+)
+def scan_nwp_zarr_archives_schedule(context: dg.ScheduleEvaluationContext) -> dg.RunRequest:
+    """Scan the zarr archives.
+
+    Yields a RunRequest for the scan_nwp_zarr_archive job for each zarr archive.
+    """
+    zarr_assets: list[dg.AssetsDefinition] = [
+        a for a in all_assets if "zarr_archive" in a.key.path
+    ]
+    for a in zarr_assets:
+        yield dg.RunRequest(
+            run_key=f"scan_nwp_{a.key.path[1]}_{a.key.path[2]}_{a.key.path[3]}",
+            run_config=jobs.gen_run_config(a.key)
+        )
+
+all_schedules: list[dg.ScheduleDefinition] = [
+    scan_nwp_raw_archives_schedule,
+    scan_nwp_zarr_archives_schedule,
+]
+

--- a/local_archives/nwp/jobs.py
+++ b/local_archives/nwp/jobs.py
@@ -216,3 +216,26 @@ def scan_nwp_zarr_archive() -> None:
     where the time values pertain to the init time.
     """
     validate_existing_zarr_files()
+
+
+def gen_run_config(asset_key: dg.AssetKey) -> dg.RunConfig:
+    """Generate a Run config for the validate_existing_files job."""
+    vc: ValidateExistingFilesConfig = ValidateExistingFilesConfig(
+        base_path=RAW_FOLDER,
+        source=asset_key.path[1],
+        area=asset_key.path[2],
+        asset_name=asset_key.path[3],
+    )
+
+    if asset_key.path[-1] == "raw_archive":
+        return dg.RunConfig(
+            ops={
+                validate_existing_raw_files.__name__: vc,
+            },
+        )
+    elif asset_key.path[-1] == "zarr_archive":
+        return dg.RunConfig(
+            ops={
+                validate_existing_zarr_files.__name__: vc,
+            },
+        )


### PR DESCRIPTION
With this PR, the scan_raw_archive and scan_zarr_archive jobs are run on a regular cadence for every raw and zarr archive. These jobs report among other things, the total sizes of the archives, so this gives visibility into the changing archive sizes.