### PR TITLE
Exit quicker on pod failure with kbatch

### DIFF
--- a/cloud_archives/ops/kbatch.py
+++ b/cloud_archives/ops/kbatch.py
@@ -223,9 +223,9 @@ def follow_kbatch_job(
             # Get the status of the job
             pods_info: list[dict] = kbc.list_pods(job_name=job_name, **KBATCH_DICT)["items"]
             new_status: str = pods_info[0]["status"]["phase"]
+            condition: str = pods_info[0]["status"]["container_statuses"][0]["state"]
             # Raise exception if job failed
             if new_status == "Failed":
-                condition: str = pods_info[0]["status"]["container_statuses"][0]["state"]
                 context.log.error(condition)
                 raise KbatchJobException(
                     message=f"Job {job_name} failed, see logs.",
@@ -242,7 +242,6 @@ def follow_kbatch_job(
                 )
             # Raise exception if timed out
             if time_spent >= timeout:
-                condition: str = pods_info[0]["status"]["container_statuses"][0]["state"]
                 context.log.error(condition)
                 raise KbatchJobException(
                     message=f"Timed out waiting for status '{old_status}' to change.",

--- a/cloud_archives/ops/kbatch.py
+++ b/cloud_archives/ops/kbatch.py
@@ -225,6 +225,8 @@ def follow_kbatch_job(
             new_status: str = pods_info[0]["status"]["phase"]
             # Raise exception if job failed
             if new_status == "Failed":
+                condition: str = pods_info[0]["status"]["container_statuses"][0]["state"]
+                context.log.error(condition)
                 raise KbatchJobException(
                     message=f"Job {job_name} failed, see logs.",
                     job_name=job_name,


### PR DESCRIPTION
Kbatch pods may fail before reaching the log streaming part, in which case we want to exit straight away without extra waits.