### PR TITLE
Prevent icon backfills from hitting commit limits in huggingface

### DIFF
--- a/cloud_archives/nwp/icon/_ops.py
+++ b/cloud_archives/nwp/icon/_ops.py
@@ -7,7 +7,6 @@ from cloud_archives.ops.generic import (
 )
 from cloud_archives.ops.huggingface import (
     HFFileConfig,
-    delete_raw_dir,
     get_hf_zarr_file_metadata,
 )
 from cloud_archives.ops.kbatch import (
@@ -41,7 +40,6 @@ def create_kbatch_huggingface_graph_config(
             get_hf_zarr_file_metadata.name + "_2": hf_config,
             log_asset_materialization.name: am_config,
             log_asset_materialization.name + "_2": am_config,
-            delete_raw_dir.name: hf_config,
         },
     )
 
@@ -65,7 +63,6 @@ def kbatch_huggingface_graph() -> dict[str, dg.MetadataValue]:
     file_metadata, no_file_after_job = get_hf_zarr_file_metadata(job_name)
     # Now the file should exist, so log the materialization
     log_asset_materialization(file_metadata)
-    delete_raw_dir(file_metadata)
     # Raise an exception if it doesn't exist at this point
     raise_exception(no_file_after_job)
 

--- a/cloud_archives/nwp/icon/icon_eu.py
+++ b/cloud_archives/nwp/icon/icon_eu.py
@@ -34,7 +34,7 @@ archive_icon_europe_job = kbatch_huggingface_graph.to_job(
         nwp_config=NWPConsumerConfig(
             source="icon",
             sink="huggingface",
-            docker_tag="0.3.1",
+            docker_tag="0.3.2",
             env={
                 "ICON_MODEL": "europe",
                 "ICON_PARAMETER_GROUP": "full",

--- a/cloud_archives/nwp/icon/icon_global.py
+++ b/cloud_archives/nwp/icon/icon_global.py
@@ -33,7 +33,7 @@ archive_icon_global_job = kbatch_huggingface_graph.to_job(
         nwp_config=NWPConsumerConfig(
             source="icon",
             sink="huggingface",
-            docker_tag="0.3.1",
+            docker_tag="0.3.2",
             env={
                 "ICON_MODEL": "global",
                 "ICON_PARAMETER_GROUP": "full",

--- a/cloud_archives/ops/huggingface.py
+++ b/cloud_archives/ops/huggingface.py
@@ -121,33 +121,3 @@ def get_hf_zarr_file_metadata(
         }
         yield dg.Output(metadata, "file_metadata")
 
-
-@dg.op(
-    ins={"depends_on": dg.In(dg.Nothing)},
-)
-def delete_raw_dir(
-    context: dg.OpExecutionContext,
-    config: HFFileConfig,
-) -> None:
-    """Dagster op to delete the raw data directory for a given inittime from huggingface.
-
-    Implements a "Nothing" input to allow for the op to have upstream dependencies without
-    the passing of data.
-
-    Args:
-        context: The dagster context.
-        config: Configuration for where to look on huggingface.
-    """
-    api = HfApi(token=os.getenv("HUGGINGFACE_TOKEN", default=None))
-    context.log.info(
-        f"Deleting raw data from repo {config.hf_repo_id}.",
-    )
-    init_time: dt.datetime = dt.datetime.strptime(config.file_init_time, "%Y-%m-%d|%H:%M").replace(
-        tzinfo=dt.UTC
-    )
-    api.delete_folder(
-        repo_id=config.hf_repo_id,
-        repo_type="dataset",
-        path_in_repo=f"raw/{init_time.strftime('%Y/%m/%d')}",
-    )
-    context.log.info(f"Deleted data directory from repo {config.hf_repo_id}.")

--- a/tests/cloud_archives/ops/kbatch_test.py
+++ b/tests/cloud_archives/ops/kbatch_test.py
@@ -34,7 +34,8 @@ class TestWaitForStatusChange(unittest.TestCase):
         mock_list_pods: MagicMock,
         mock_sleep: MagicMock,
     ) -> None:
-        wait_for_status_change(old_status="Pending", job_name="test-job")
+        new_status = wait_for_status_change(old_status="Pending", job_name="test-job")
+        self.assertEqual(new_status, "Running")
         # Make sure list_pods is called for each status check
         self.assertEqual(mock_list_pods.call_count, 3)
 
@@ -51,8 +52,8 @@ class TestWaitForStatusChange(unittest.TestCase):
         mock_list_pods: MagicMock,
         mock_sleep: MagicMock,
     ) -> None:
-        with self.assertRaises(KbatchJobException):
-            wait_for_status_change(old_status="Pending", job_name="test-job")
+        new_status = wait_for_status_change(old_status="Pending", job_name="test-job")
+        self.assertEqual(new_status, "Failed")
         # Make sure list_pods is called
         self.assertEqual(mock_list_pods.call_count, 2)
 
@@ -66,8 +67,8 @@ class TestWaitForStatusChange(unittest.TestCase):
         mock_list_pods: MagicMock,
         mock_sleep: MagicMock,
     ) -> None:
-        with self.assertRaises(KbatchJobException):
-            wait_for_status_change(old_status="Pending", job_name="test-job")
+        new_status = wait_for_status_change(old_status="Pending", job_name="test-job")
+        self.assertEqual(new_status, "Pending")
         # Make sure list_pods is called
         self.assertGreater(mock_list_pods.call_count, 1)
         # Make sure time.sleep is called multiple times

--- a/tests/cloud_archives/ops/kbatch_test.py
+++ b/tests/cloud_archives/ops/kbatch_test.py
@@ -67,8 +67,9 @@ class TestWaitForStatusChange(unittest.TestCase):
         mock_list_pods: MagicMock,
         mock_sleep: MagicMock,
     ) -> None:
-        new_status = wait_for_status_change(old_status="Pending", job_name="test-job")
-        self.assertEqual(new_status, "Pending")
+        with self.assertRaises(KbatchJobException):
+            new_status = wait_for_status_change(old_status="Pending", job_name="test-job")
+            self.assertEqual(new_status, "Pending")
         # Make sure list_pods is called
         self.assertGreater(mock_list_pods.call_count, 1)
         # Make sure time.sleep is called multiple times


### PR DESCRIPTION
Uses the newly updated NWP Consumer "rawsink" option