### PR TITLE
fix(gfs): Modify gfs asset to use subprocess pipes client

### DIFF
--- a/containers/gfs/download_combine_gfs.py
+++ b/containers/gfs/download_combine_gfs.py
@@ -101,11 +101,20 @@ def convert_file(file: str, outfolder: str) -> str | None:
             d = d.rename({variable: f"{variable}_{d[f'{variable}'].attrs['GRIB_stepType']}"})
         heightAboveGround[i] = d
 
-    surface_merged: xr.Dataset = xr.merge(surface).drop_vars("unknown_surface_instant", errors="ignore")
+    surface_merged: xr.Dataset = xr.merge(surface).drop_vars(
+        ["unknown_surface_instant", "valid_time"],
+        errors="ignore",
+    )
     del surface
-    heightAboveGround_merged: xr.Dataset = xr.merge(heightAboveGround)
+    heightAboveGround_merged: xr.Dataset = xr.merge(heightAboveGround).drop_vars(
+        "valid_time",
+        errors="ignore",
+    )
     del heightAboveGround
-    isobaricInhPa_merged: xr.Dataset = xr.merge(isobaricInhPa)
+    isobaricInhPa_merged: xr.Dataset = xr.merge(isobaricInhPa).drop_vars(
+        "valid_time",
+        errors="ignore",
+    )
     del isobaricInhPa
 
     total_ds: xr.Dataset = (

--- a/local_archives/nwp/gfs/gfs.py
+++ b/local_archives/nwp/gfs/gfs.py
@@ -39,20 +39,4 @@ def zarr_archive(
             ZARR_FOLDER + "/nwp/gfs/global",
         ),
     ).get_materialize_result()
-    """
-    return pipes_docker_client.run(
-        context=context,
-        image="ghcr.io/openclimatefix/gfs-etl:main",
-        command=[
-            "--date",
-            context.partition_time_window.start.strftime("%Y-%m-%d"),
-            "--path",
-            "/data",
-        ],
-        container_kwargs={
-            "volumes": {
-                f"{ZARR_FOLDER}/nwp/gfs/global": {"bind": "/data", "mode": "rw"},
-            },
-        },
-    ).get_materialize_result()
-    """
+


### PR DESCRIPTION
Currently docker is not able to allocate memory to run containers. In the meantime while I fix it, use suprocess to run python gfs downloads.